### PR TITLE
feat: support-override-autoware-launch-arg

### DIFF
--- a/docs/use_case/annotationless_perception.en.md
+++ b/docs/use_case/annotationless_perception.en.md
@@ -188,49 +188,10 @@ dlr simulation run -p annotationless_perception -u ${existing|all}
 
 ## Arguments passed to logging_simulator.launch
 
-To make Autoware processing less resource-consuming, modules that are not relevant to evaluation are disabled by passing the `false` parameter as a launch argument.
-The following parameters are set to `false`:
-
-- perception: true
+- localization: false
 - planning: false
 - control: false
 - use_perception_online_evaluator: true
-
-### Arguments specified in the scenario or launch command
-
-- sensing: It can be disabled by specifying LaunchSensing: false in the scenario. Or specify sensing:=false in the launch command
-
-### How to specify the sensing argument
-
-#### driving-log-replayer-cli
-
-```shell
-dlr simulation run -p annotationless_perception -l sensing:=true
-```
-
-#### WebAutoCLI
-
-```shell
-webauto ci scenario run --project-id ${project-id} --scenario-id ${scenario-id} --scenario-version-id ${scenario-version-id} --simulator-parameter-overrides 'sensing=true'
-```
-
-#### Autoware Evaluator
-
-Add to parameters in the simulator configuration in `.webauto-ci.yml`.
-
-```yaml
-simulations:
-  - name: annotationless_perception
-    type: annotationless_perception
-    simulator:
-      deployment:
-        type: container
-        artifact: main
-      runtime:
-        type: simulator/standard1/amd64/medium
-      parameters:
-        sensing: "true"
-```
 
 ## simulation
 

--- a/docs/use_case/annotationless_perception.ja.md
+++ b/docs/use_case/annotationless_perception.ja.md
@@ -188,48 +188,10 @@ dlr simulation run -p annotationless_perception -u ${existing|all}
 
 ## logging_simulator.launch に渡す引数
 
-autoware の処理を軽くするため、評価に関係のないモジュールは launch の引数に false を渡すことで無効化する。以下を設定している。
-
-- perception: true
+- localization: false
 - planning: false
 - control: false
 - use_perception_online_evaluator: true
-
-### シナリオまたはlaunchコマンドで指定する引数
-
-- sensing: シナリオにLaunchSensing: falseを指定することで無効化できる。またはlaunchコマンドでsensing:=falseを指定する
-
-### sensingの引数指定方法
-
-#### driving-log-replayer-cli
-
-```shell
-dlr simulation run -p annotationless_perception -l sensing:=true
-```
-
-#### WebAutoCLI
-
-```shell
-webauto ci scenario run --project-id ${project-id} --scenario-id ${scenario-id} --scenario-version-id ${scenario-version-id} --simulator-parameter-overrides 'sensing=true'
-```
-
-#### Autoware Evaluator
-
-.webauto-ci.ymlのsimulatorの設定でparametersに追加する。
-
-```yaml
-simulations:
-  - name: annotationless_perception
-    type: annotationless_perception
-    simulator:
-      deployment:
-        type: container
-        artifact: main
-      runtime:
-        type: simulator/standard1/amd64/medium
-      parameters:
-        sensing: "true"
-```
 
 ## simulation
 

--- a/docs/use_case/ar_tag_based_localizer.en.md
+++ b/docs/use_case/ar_tag_based_localizer.en.md
@@ -52,9 +52,6 @@ Published topics:
 
 ## Arguments passed to logging_simulator.launch
 
-To make Autoware processing less resource-consuming, modules that are not relevant to evaluation are disabled by passing the `false` parameter as a launch argument.
-The following parameters are set to `false`:
-
 - perception: false
 - planning: false
 - control: false

--- a/docs/use_case/ar_tag_based_localizer.ja.md
+++ b/docs/use_case/ar_tag_based_localizer.ja.md
@@ -54,8 +54,6 @@ Published topics:
 
 ## logging_simulator.launch に渡す引数
 
-autoware の処理を軽くするため、評価に関係のないモジュールは launch の引数に false を渡すことで無効化する。以下を設定している。
-
 - perception: false
 - planning: false
 - control: false

--- a/docs/use_case/eagleye.en.md
+++ b/docs/use_case/eagleye.en.md
@@ -51,9 +51,6 @@ Published topics:
 
 ## Arguments passed to logging_simulator.launch
 
-To make Autoware processing less resource-consuming, modules that are not relevant to evaluation are disabled by passing the `false` parameter as a launch argument.
-The following parameters are set to `false`:
-
 - perception: false
 - planning: false
 - control: false

--- a/docs/use_case/eagleye.ja.md
+++ b/docs/use_case/eagleye.ja.md
@@ -61,8 +61,6 @@ Published topics:
 
 ## logging_simulator.launch に渡す引数
 
-autoware の処理を軽くするため、評価に関係のないモジュールは launch の引数に false を渡すことで無効化する。以下を設定している。
-
 - perception: false
 - planning: false
 - control: false

--- a/docs/use_case/localization.en.md
+++ b/docs/use_case/localization.en.md
@@ -108,9 +108,6 @@ Published topics:
 
 ## Arguments passed to logging_simulator.launch
 
-To make Autoware processing less resource-consuming, modules that are not relevant to evaluation are disabled by passing the `false` parameter as a launch argument.
-The following parameters are set to `false`:
-
 - perception: false
 - planning: false
 - control: false

--- a/docs/use_case/localization.ja.md
+++ b/docs/use_case/localization.ja.md
@@ -108,8 +108,6 @@ Published topics:
 
 ## logging_simulator.launch に渡す引数
 
-autoware の処理を軽くするため、評価に関係のないモジュールは launch の引数に false を渡すことで無効化する。以下を設定している。
-
 - perception: false
 - planning: false
 - control: false

--- a/docs/use_case/obstacle_segmentation.en.md
+++ b/docs/use_case/obstacle_segmentation.en.md
@@ -93,11 +93,9 @@ Published topics:
 
 ## Arguments passed to logging_simulator.launch
 
-To make Autoware processing less resource-consuming, modules that are not relevant to evaluation are disabled by passing the `false` parameter as a launch argument.
-The following parameters are set to `false`:
-
 - localization: false
 - control: false
+- scenario_simulation: true
 
 ## About simulation
 

--- a/docs/use_case/obstacle_segmentation.ja.md
+++ b/docs/use_case/obstacle_segmentation.ja.md
@@ -94,10 +94,9 @@ Published topics:
 
 ## logging_simulator.launch に渡す引数
 
-autoware の処理を軽くするため、評価に関係のないモジュールは launch の引数に false を渡すことで無効化する。以下を設定する。
-
 - localization: false
 - control: false
+- scenario_simulation: true
 
 ## simulation
 

--- a/docs/use_case/perception.en.md
+++ b/docs/use_case/perception.en.md
@@ -134,18 +134,11 @@ Published topics:
 
 ## Arguments passed to logging_simulator.launch
 
-To make Autoware processing less resource-consuming, modules that are not relevant to evaluation are disabled by passing the `false` parameter as a launch argument.
-The following parameters are set to `false`:
-
 - localization: false
 - planning: false
 - control: false
 
 **NOTE: The `tf` in the bag is used to align the localization during annotation and simulation. Therefore, localization is invalid.**
-
-### Arguments specified in the scenario or launch command
-
-- sensing: It can be disabled by specifying LaunchSensing: false in the scenario. Or specify sensing:=false in the launch command
 
 ## Dependent libraries
 

--- a/docs/use_case/perception.ja.md
+++ b/docs/use_case/perception.ja.md
@@ -130,17 +130,11 @@ Published topics:
 
 ## logging_simulator.launch に渡す引数
 
-autoware の処理を軽くするため、評価に関係のないモジュールは launch の引数に false を渡すことで無効化する。以下を設定している。
-
 - localization: false
 - planning: false
 - control: false
 
 **注:アノーテション時とシミュレーション時で自己位置を合わせたいので bag に入っている tf を使い回す。そのため localization は無効である。**
-
-### シナリオまたはlaunchコマンドで指定する引数
-
-- sensing: シナリオにLaunchSensing: falseを指定することで無効化できる。またはlaunchコマンドでsensing:=falseを指定する
 
 ## 依存ライブラリ
 

--- a/docs/use_case/perception_2d.en.md
+++ b/docs/use_case/perception_2d.en.md
@@ -162,19 +162,12 @@ Published topics:
 
 ## Arguments passed to logging_simulator.launch
 
-To make Autoware processing less resource-consuming, modules that are not relevant to evaluation are disabled by passing the `false` parameter as a launch argument.
-The following parameters are set to `false`:
-
 - localization: false
 - planning: false
 - control: false
 - perception_mode: camera_lidar_fusion
 
 **NOTE: The `tf` in the bag is used to align the localization during annotation and simulation. Therefore, localization is invalid.**
-
-### Arguments specified in the scenario or launch command
-
-- sensing: It can be disabled by specifying LaunchSensing: false in the scenario. Or specify sensing:=false in the launch command
 
 ## Dependent libraries
 

--- a/docs/use_case/perception_2d.ja.md
+++ b/docs/use_case/perception_2d.ja.md
@@ -163,18 +163,12 @@ Published topics:
 
 ## logging_simulator.launch に渡す引数
 
-autoware の処理を軽くするため、評価に関係のないモジュールは launch の引数に false を渡すことで無効化する。以下を設定している。
-
 - localization: false
 - planning: false
 - control: false
 - perception_mode: camera_lidar_fusion
 
 **注:アノーテション時とシミュレーション時で自己位置を合わせたいので bag に入っている tf を使い回す。そのため localization は無効である。**
-
-### シナリオまたはlaunchコマンドで指定する引数
-
-- sensing: シナリオにLaunchSensing: falseを指定することで無効化できる。またはlaunchコマンドでsensing:=falseを指定する
 
 ## 依存ライブラリ
 

--- a/docs/use_case/performance_diag.en.md
+++ b/docs/use_case/performance_diag.en.md
@@ -86,16 +86,9 @@ Published topics:
 
 ## Arguments passed to logging_simulator.launch
 
-To make Autoware processing less resource-consuming, modules that are not relevant to evaluation are disabled by passing the `false` parameter as a launch argument.
-The following parameters are set to `false`:
-
 - perception: false
 - planning: false
 - control: false
-
-### Arguments specified in the scenario or launch command
-
-- localization: It can be disabled by specifying LaunchLocalization: false in the scenario. Or specify localization:=false in the launch command
 
 ## About simulation
 

--- a/docs/use_case/performance_diag.ja.md
+++ b/docs/use_case/performance_diag.ja.md
@@ -86,15 +86,9 @@ Published topics:
 
 ## logging_simulator.launch に渡す引数
 
-autoware の処理を軽くするため、評価に関係のないモジュールは launch の引数に false を渡すことで無効化する。以下を設定している。
-
 - perception: false
 - planning: false
 - control: false
-
-### シナリオまたはlaunchコマンドで指定する引数
-
-- localization: シナリオにLaunchLocalization: falseを指定することで無効化できる。またはlaunchコマンドでlocalization:=falseを指定する
 
 ## simulation
 

--- a/docs/use_case/traffic_light.en.md
+++ b/docs/use_case/traffic_light.en.md
@@ -110,19 +110,11 @@ Published topics:
 
 ## Arguments passed to logging_simulator.launch
 
-To make Autoware processing less resource-consuming, modules that are not relevant to evaluation are disabled by passing the `false` parameter as a launch argument.
-The following parameters are set to `false`:
-
 - localization: false
 - planning: false
 - control: false
-- perception_mode: camera_lidar_fusion
 
 **NOTE: The `tf` in the bag is used to align the localization during annotation and simulation. Therefore, localization is invalid.**
-
-### Arguments specified in the scenario or launch command
-
-- sensing: It can be disabled by specifying LaunchSensing: false in the scenario. Or specify sensing:=false in the launch command
 
 ## Dependent libraries
 

--- a/docs/use_case/traffic_light.ja.md
+++ b/docs/use_case/traffic_light.ja.md
@@ -116,17 +116,11 @@ Published topics:
 
 ## logging_simulator.launch に渡す引数
 
-autoware の処理を軽くするため、評価に関係のないモジュールは launch の引数に false を渡すことで無効化する。以下を設定している。
-
 - localization: false
 - planning: false
 - control: false
 
 **注:アノーテション時とシミュレーション時で自己位置を合わせたいので bag に入っている tf を使い回す。そのため localization は無効である。**
-
-### シナリオまたはlaunchコマンドで指定する引数
-
-- sensing: シナリオにLaunchSensing: falseを指定することで無効化できる。またはlaunchコマンドでsensing:=falseを指定する
 
 ## 依存ライブラリ
 

--- a/docs/use_case/yabloc.en.md
+++ b/docs/use_case/yabloc.en.md
@@ -51,9 +51,6 @@ Published topics:
 
 ## Arguments passed to logging_simulator.launch
 
-To make Autoware processing less resource-consuming, modules that are not relevant to evaluation are disabled by passing the `false` parameter as a launch argument.
-The following parameters are set to `false`:
-
 - perception: false
 - planning: false
 - control: false

--- a/docs/use_case/yabloc.ja.md
+++ b/docs/use_case/yabloc.ja.md
@@ -61,8 +61,6 @@ Published topics:
 
 ## logging_simulator.launch に渡す引数
 
-autoware の処理を軽くするため、評価に関係のないモジュールは launch の引数に false を渡すことで無効化する。以下を設定している。
-
 - perception: false
 - planning: false
 - control: false

--- a/log_evaluator/launch/log_evaluator.launch.py
+++ b/log_evaluator/launch/log_evaluator.launch.py
@@ -109,12 +109,6 @@ def ensure_arg_compatibility(context: LaunchContext) -> list:
     for k, v in datasets[dataset_index].items():
         dataset_path = dataset_dir.joinpath(k)
         conf["vehicle_id"] = v["VehicleId"]
-        launch_sensing = yaml_obj["Evaluation"].get("LaunchSensing")
-        launch_localization = yaml_obj["Evaluation"].get("LaunchLocalization")
-        if launch_sensing is not None:
-            conf["sensing"] = str(launch_sensing)
-        if launch_localization is not None:
-            conf["localization"] = str(launch_localization)
     conf["map_path"] = dataset_path.joinpath("map").as_posix()
     conf["vehicle_model"] = yaml_obj["VehicleModel"]
     conf["sensor_model"] = yaml_obj["SensorModel"]
@@ -124,6 +118,16 @@ def ensure_arg_compatibility(context: LaunchContext) -> list:
     conf["result_bag_path"] = output_dir.joinpath("result_bag").as_posix()
     conf["result_archive_path"] = output_dir.joinpath("result_archive_path").as_posix()
     conf["use_case"] = yaml_obj["Evaluation"]["UseCaseName"]
+    use_case_launch_arg = log_evaluator_config[conf["use_case"]]["disable"]
+    # update autoware component launch or not
+    autoware_components = ["sensing", "localization", "perception", "planning", "control"]
+    launch_component = {}
+    for component in autoware_components:
+        # argument has higher priority than the launch_config.py setting.
+        if conf.get(component) is None and use_case_launch_arg.get(component) is not None:
+            conf[component] = use_case_launch_arg[component]
+        launch_component[component] = conf.get(component, "true")
+
     # annotationless
     conf["annotationless_threshold_file"] = ""
     conf["annotationless_pass_range"] = ""
@@ -134,6 +138,9 @@ def ensure_arg_compatibility(context: LaunchContext) -> list:
     return [
         LogInfo(
             msg=f"{dataset_path=}, {dataset_index=}, {output_dir=}, use_case={conf['use_case']}",
+        ),
+        LogInfo(
+            msg=f"{launch_component=}",
         ),
     ]
 

--- a/log_evaluator/log_evaluator/launch_config.py
+++ b/log_evaluator/log_evaluator/launch_config.py
@@ -26,10 +26,13 @@ LOCALIZATION_RECORD_TOPIC = """^/tf$\
 |^/log_evaluator/.*\
 """
 
-LOCALIZATION_AUTOWARE_ARGS = {
+LOCALIZATION_AUTOWARE_DISABLE = {
     "perception": "false",
     "planning": "false",
     "control": "false",
+}
+
+LOCALIZATION_AUTOWARE_ARGS = {
     "pose_source": "ndt",
     "twist_source": "gyro_odom",
 }
@@ -44,10 +47,9 @@ EAGLEYE_RECORD_TOPIC = """^/tf$\
 |^/localization/pose_estimator/points_aligned$\
 """
 
+EAGLEYE_AUTOWARE_DISABLE = {"perception": "false", "planning": "false", "control": "false"}
+
 EAGLEYE_AUTOWARE_ARGS = {
-    "perception": "false",
-    "planning": "false",
-    "control": "false",
     "pose_source": "eagleye",
     "twist_source": "eagleye",
 }
@@ -60,10 +62,13 @@ AR_TAG_BASED_LOCALIZER_RECORD_TOPIC = """^/tf$\
 |^/localization/kinematic_state$\
 """
 
-AR_TAG_BASED_LOCALIZER_AUTOWARE_ARGS = {
+AR_TAG_BASED_LOCALIZER_AUTOWARE_DISABLE = {
     "perception": "false",
     "planning": "false",
     "control": "false",
+}
+
+AR_TAG_BASED_LOCALIZER_AUTOWARE_ARGS = {
     "pose_source": "artag",
     "twist_source": "gyro_odom",
 }
@@ -78,10 +83,13 @@ YABLOC_RECORD_TOPIC = """^/tf$\
 |^/localization/pose_estimator/points_aligned$\
 """
 
-YABLOC_AUTOWARE_ARGS = {
+YABLOC_AUTOWARE_DISABLE = {
     "perception": "false",
     "planning": "false",
     "control": "false",
+}
+
+YABLOC_AUTOWARE_ARGS = {
     "pose_source": "yabloc",
     "twist_source": "gyro_odom",
 }
@@ -99,12 +107,14 @@ PERCEPTION_RECORD_TOPIC = """^/tf$\
 |^/sensing/camera/.*\
 """
 
-
-PERCEPTION_AUTOWARE_ARGS = {
+PERCEPTION_AUTOWARE_DISABLE = {
+    "sensing": "false",
     "localization": "false",
     "planning": "false",
     "control": "false",
 }
+
+PERCEPTION_AUTOWARE_ARGS = {}
 
 PERCEPTION_NODE_PARAMS = {}
 
@@ -115,10 +125,12 @@ OBSTACLE_SEGMENTATION_RECORD_TOPIC = """^/tf$\
 |^/log_evaluator/.*\
 """
 
-OBSTACLE_SEGMENTATION_AUTOWARE_ARGS = {
+OBSTACLE_SEGMENTATION_AUTOWARE_DISABLE = {
     "localization": "false",
-    "planning": "true",
     "control": "false",
+}
+
+OBSTACLE_SEGMENTATION_AUTOWARE_ARGS = {
     "scenario_simulation": "true",
 }
 
@@ -133,11 +145,14 @@ TRAFFIC_LIGHT_RECORD_TOPIC = """^/tf$\
 |^/log_evaluator/.*\
 """
 
-TRAFFIC_LIGHT_AUTOWARE_ARGS = {
+TRAFFIC_LIGHT_AUTOWARE_DISABLE = {
+    "sensing": "false",
     "localization": "false",
     "planning": "false",
     "control": "false",
 }
+
+TRAFFIC_LIGHT_AUTOWARE_ARGS = {}
 
 TRAFFIC_LIGHT_NODE_PARAMS = {"map_path": LaunchConfiguration("map_path")}
 
@@ -149,11 +164,15 @@ PERFORMANCE_DIAG_RECORD_TOPIC = """^/tf$\
 |^/log_evaluator/.*\
 """
 
-PERFORMANCE_DIAG_AUTOWARE_ARGS = {
+PERFORMANCE_DIAG_AUTOWARE_DISABLE = {
+    "localization": "false",
     "perception": "false",
     "planning": "false",
     "control": "false",
 }
+
+
+PERFORMANCE_DIAG_AUTOWARE_ARGS = {}
 
 PERFORMANCE_DIAG_NODE_PARAMS = {}
 
@@ -166,10 +185,14 @@ PERCEPTION_2D_RECORD_TOPIC = """^/tf$\
 |^/log_evaluator/.*\
 """
 
-PERCEPTION_2D_AUTOWARE_ARGS = {
+PERCEPTION_2D_AUTOWARE_DISABLE = {
+    "sensing": "false",
     "localization": "false",
     "planning": "false",
     "control": "false",
+}
+
+PERCEPTION_2D_AUTOWARE_ARGS = {
     "perception_mode": "camera_lidar_fusion",
 }
 
@@ -185,10 +208,14 @@ ANNOTATIONLESS_PERCEPTION_RECORD_TOPIC = """^/tf$\
 |^/diagnostic/perception_online_evaluator/.*\
 """
 
-ANNOTATIONLESS_PERCEPTION_AUTOWARE_ARGS = {
+ANNOTATIONLESS_PERCEPTION_AUTOWARE_DISABLE = {
+    "sensing": "false",
     "localization": "false",
     "planning": "false",
     "control": "false",
+}
+
+ANNOTATIONLESS_PERCEPTION_AUTOWARE_ARGS = {
     "use_perception_online_evaluator": "true",
 }
 
@@ -206,51 +233,61 @@ ANNOTATIONLESS_PERCEPTION_NODE_PARAMS = {
 log_evaluator_config = {
     "localization": {
         "record": LOCALIZATION_RECORD_TOPIC,
+        "disable": LOCALIZATION_AUTOWARE_DISABLE,
         "autoware": LOCALIZATION_AUTOWARE_ARGS,
         "node": LOCALIZATION_NODE_PARAMS,
     },
     "eagleye": {
         "record": EAGLEYE_RECORD_TOPIC,
+        "disable": EAGLEYE_AUTOWARE_DISABLE,
         "autoware": EAGLEYE_AUTOWARE_ARGS,
         "node": EAGLEYE_NODE_PARAMS,
     },
     "ar_tag_based_localizer": {
         "record": AR_TAG_BASED_LOCALIZER_RECORD_TOPIC,
+        "disable": AR_TAG_BASED_LOCALIZER_AUTOWARE_DISABLE,
         "autoware": AR_TAG_BASED_LOCALIZER_AUTOWARE_ARGS,
         "node": AR_TAG_BASED_LOCALIZER_NODE_PARAMS,
     },
     "yabloc": {
         "record": YABLOC_RECORD_TOPIC,
+        "disable": YABLOC_AUTOWARE_DISABLE,
         "autoware": YABLOC_AUTOWARE_ARGS,
         "node": YABLOC_NODE_PARAMS,
     },
     "perception": {
         "record": PERCEPTION_RECORD_TOPIC,
+        "disable": PERCEPTION_AUTOWARE_DISABLE,
         "autoware": PERCEPTION_AUTOWARE_ARGS,
         "node": PERCEPTION_NODE_PARAMS,
     },
     "obstacle_segmentation": {
         "record": OBSTACLE_SEGMENTATION_RECORD_TOPIC,
+        "disable": OBSTACLE_SEGMENTATION_AUTOWARE_DISABLE,
         "autoware": OBSTACLE_SEGMENTATION_AUTOWARE_ARGS,
         "node": OBSTACLE_SEGMENTATION_NODE_PARAMS,
     },
     "traffic_light": {
         "record": TRAFFIC_LIGHT_RECORD_TOPIC,
+        "disable": TRAFFIC_LIGHT_AUTOWARE_DISABLE,
         "autoware": TRAFFIC_LIGHT_AUTOWARE_ARGS,
         "node": TRAFFIC_LIGHT_NODE_PARAMS,
     },
     "performance_diag": {
         "record": PERFORMANCE_DIAG_RECORD_TOPIC,
+        "disable": PERFORMANCE_DIAG_AUTOWARE_DISABLE,
         "autoware": PERFORMANCE_DIAG_AUTOWARE_ARGS,
         "node": PERFORMANCE_DIAG_NODE_PARAMS,
     },
     "perception_2d": {
         "record": PERCEPTION_2D_RECORD_TOPIC,
+        "disable": PERCEPTION_2D_AUTOWARE_DISABLE,
         "autoware": PERCEPTION_AUTOWARE_ARGS,
         "node": PERCEPTION_2D_NODE_PARAMS,
     },
     "annotationless_perception": {
         "record": ANNOTATIONLESS_PERCEPTION_RECORD_TOPIC,
+        "disable": ANNOTATIONLESS_PERCEPTION_AUTOWARE_DISABLE,
         "autoware": ANNOTATIONLESS_PERCEPTION_AUTOWARE_ARGS,
         "node": ANNOTATIONLESS_PERCEPTION_NODE_PARAMS,
     },

--- a/log_evaluator/log_evaluator/launch_config.py
+++ b/log_evaluator/log_evaluator/launch_config.py
@@ -108,7 +108,6 @@ PERCEPTION_RECORD_TOPIC = """^/tf$\
 """
 
 PERCEPTION_AUTOWARE_DISABLE = {
-    "sensing": "false",
     "localization": "false",
     "planning": "false",
     "control": "false",
@@ -146,7 +145,6 @@ TRAFFIC_LIGHT_RECORD_TOPIC = """^/tf$\
 """
 
 TRAFFIC_LIGHT_AUTOWARE_DISABLE = {
-    "sensing": "false",
     "localization": "false",
     "planning": "false",
     "control": "false",
@@ -165,7 +163,6 @@ PERFORMANCE_DIAG_RECORD_TOPIC = """^/tf$\
 """
 
 PERFORMANCE_DIAG_AUTOWARE_DISABLE = {
-    "localization": "false",
     "perception": "false",
     "planning": "false",
     "control": "false",
@@ -186,7 +183,6 @@ PERCEPTION_2D_RECORD_TOPIC = """^/tf$\
 """
 
 PERCEPTION_2D_AUTOWARE_DISABLE = {
-    "sensing": "false",
     "localization": "false",
     "planning": "false",
     "control": "false",
@@ -209,7 +205,6 @@ ANNOTATIONLESS_PERCEPTION_RECORD_TOPIC = """^/tf$\
 """
 
 ANNOTATIONLESS_PERCEPTION_AUTOWARE_DISABLE = {
-    "sensing": "false",
     "localization": "false",
     "planning": "false",
     "control": "false",

--- a/log_evaluator/log_evaluator/launch_config.py
+++ b/log_evaluator/log_evaluator/launch_config.py
@@ -15,185 +15,6 @@
 from launch.substitutions import LaunchConfiguration
 from launch_ros.descriptions import ParameterValue
 
-LOCALIZATION_RECORD_TOPIC = """^/tf$\
-|^/diagnostics$\
-|^/localization/pose_estimator/transform_probability$\
-|^/localization/pose_estimator/nearest_voxel_transformation_likelihood$\
-|^/localization/pose_estimator/pose$\
-|^/localization/kinematic_state$\
-|^/localization/util/downsample/pointcloud$\
-|^/localization/pose_estimator/points_aligned$\
-|^/log_evaluator/.*\
-"""
-
-LOCALIZATION_AUTOWARE_DISABLE = {
-    "perception": "false",
-    "planning": "false",
-    "control": "false",
-}
-
-LOCALIZATION_AUTOWARE_ARGS = {
-    "pose_source": "ndt",
-    "twist_source": "gyro_odom",
-}
-
-LOCALIZATION_NODE_PARAMS = {}
-
-EAGLEYE_RECORD_TOPIC = """^/tf$\
-|^/diagnostics$"\
-|^/localization/kinematic_state$\
-|^/localization/pose_estimator/pose$\
-|^/localization/util/downsample/pointcloud$\
-|^/localization/pose_estimator/points_aligned$\
-"""
-
-EAGLEYE_AUTOWARE_DISABLE = {"perception": "false", "planning": "false", "control": "false"}
-
-EAGLEYE_AUTOWARE_ARGS = {
-    "pose_source": "eagleye",
-    "twist_source": "eagleye",
-}
-
-EAGLEYE_NODE_PARAMS = {}
-
-
-AR_TAG_BASED_LOCALIZER_RECORD_TOPIC = """^/tf$\
-|^/diagnostics$"\
-|^/localization/kinematic_state$\
-"""
-
-AR_TAG_BASED_LOCALIZER_AUTOWARE_DISABLE = {
-    "perception": "false",
-    "planning": "false",
-    "control": "false",
-}
-
-AR_TAG_BASED_LOCALIZER_AUTOWARE_ARGS = {
-    "pose_source": "artag",
-    "twist_source": "gyro_odom",
-}
-
-AR_TAG_BASED_LOCALIZER_NODE_PARAMS = {}
-
-YABLOC_RECORD_TOPIC = """^/tf$\
-|^/diagnostics$\
-|^/localization/pose_estimator/pose$\
-|^/localization/kinematic_state$\
-|^/localization/util/downsample/pointcloud$\
-|^/localization/pose_estimator/points_aligned$\
-"""
-
-YABLOC_AUTOWARE_DISABLE = {
-    "perception": "false",
-    "planning": "false",
-    "control": "false",
-}
-
-YABLOC_AUTOWARE_ARGS = {
-    "pose_source": "yabloc",
-    "twist_source": "gyro_odom",
-}
-
-YABLOC_NODE_PARAMS = {}
-
-PERCEPTION_RECORD_TOPIC = """^/tf$\
-|^/sensing/lidar/concatenated/pointcloud$\
-|^/perception/object_recognition/detection/objects$\
-|^/perception/object_recognition/tracking/objects$\
-|^/perception/object_recognition/objects$\
-|^/perception/object_recognition/tracking/multi_object_tracker/debug/.*\
-|^/perception/object_recognition/detection/.*/debug/pipeline_latency_ms$\
-|^/log_evaluator/.*\
-|^/sensing/camera/.*\
-"""
-
-PERCEPTION_AUTOWARE_DISABLE = {
-    "localization": "false",
-    "planning": "false",
-    "control": "false",
-}
-
-PERCEPTION_AUTOWARE_ARGS = {}
-
-PERCEPTION_NODE_PARAMS = {}
-
-OBSTACLE_SEGMENTATION_RECORD_TOPIC = """^/tf$\
-|^/perception/obstacle_segmentation/pointcloud$\
-|^/planning/scenario_planning/trajectory$\
-|^/planning/scenario_planning/status/stop_reasons$\
-|^/log_evaluator/.*\
-"""
-
-OBSTACLE_SEGMENTATION_AUTOWARE_DISABLE = {
-    "localization": "false",
-    "control": "false",
-}
-
-OBSTACLE_SEGMENTATION_AUTOWARE_ARGS = {
-    "scenario_simulation": "true",
-}
-
-OBSTACLE_SEGMENTATION_NODE_PARAMS = {
-    "vehicle_model": LaunchConfiguration("vehicle_model"),
-    "map_path": LaunchConfiguration("map_path"),
-}
-
-TRAFFIC_LIGHT_RECORD_TOPIC = """^/tf$\
-|^/sensing/camera/camera[67]/image_raw/compressed$\
-|^/perception/.*/traffic_signals$\
-|^/log_evaluator/.*\
-"""
-
-TRAFFIC_LIGHT_AUTOWARE_DISABLE = {
-    "localization": "false",
-    "planning": "false",
-    "control": "false",
-}
-
-TRAFFIC_LIGHT_AUTOWARE_ARGS = {}
-
-TRAFFIC_LIGHT_NODE_PARAMS = {"map_path": LaunchConfiguration("map_path")}
-
-PERFORMANCE_DIAG_RECORD_TOPIC = """^/tf$\
-|^/perception/obstacle_segmentation/pointcloud$\
-|^/diagnostics$\
-|^/sensing/lidar/.*/blockage_diag/debug/blockage_mask_image$\
-|^/sensing/lidar/.*/pointcloud_raw_ex$\
-|^/log_evaluator/.*\
-"""
-
-PERFORMANCE_DIAG_AUTOWARE_DISABLE = {
-    "perception": "false",
-    "planning": "false",
-    "control": "false",
-}
-
-
-PERFORMANCE_DIAG_AUTOWARE_ARGS = {}
-
-PERFORMANCE_DIAG_NODE_PARAMS = {}
-
-PERCEPTION_2D_RECORD_TOPIC = """^/tf$\
-|^/sensing/lidar/concatenated/pointcloud$\
-|^/perception/object_recognition/detection/objects$\
-|^/perception/object_recognition/tracking/objects$\
-|^/perception/object_recognition/objects$\
-|^/sensing/camera/.*\
-|^/log_evaluator/.*\
-"""
-
-PERCEPTION_2D_AUTOWARE_DISABLE = {
-    "localization": "false",
-    "planning": "false",
-    "control": "false",
-}
-
-PERCEPTION_2D_AUTOWARE_ARGS = {
-    "perception_mode": "camera_lidar_fusion",
-}
-
-PERCEPTION_2D_NODE_PARAMS = {}
-
 ANNOTATIONLESS_PERCEPTION_RECORD_TOPIC = """^/tf$\
 |^/sensing/lidar/concatenated/pointcloud$\
 |^/perception/object_recognition/detection/objects$\
@@ -225,18 +46,190 @@ ANNOTATIONLESS_PERCEPTION_NODE_PARAMS = {
     ),
 }
 
+AR_TAG_BASED_LOCALIZER_RECORD_TOPIC = """^/tf$\
+|^/diagnostics$"\
+|^/localization/kinematic_state$\
+"""
+
+AR_TAG_BASED_LOCALIZER_AUTOWARE_DISABLE = {
+    "perception": "false",
+    "planning": "false",
+    "control": "false",
+}
+
+AR_TAG_BASED_LOCALIZER_AUTOWARE_ARGS = {
+    "pose_source": "artag",
+    "twist_source": "gyro_odom",
+}
+
+AR_TAG_BASED_LOCALIZER_NODE_PARAMS = {}
+
+EAGLEYE_RECORD_TOPIC = """^/tf$\
+|^/diagnostics$"\
+|^/localization/kinematic_state$\
+|^/localization/pose_estimator/pose$\
+|^/localization/util/downsample/pointcloud$\
+|^/localization/pose_estimator/points_aligned$\
+"""
+
+EAGLEYE_AUTOWARE_DISABLE = {"perception": "false", "planning": "false", "control": "false"}
+
+EAGLEYE_AUTOWARE_ARGS = {
+    "pose_source": "eagleye",
+    "twist_source": "eagleye",
+}
+
+EAGLEYE_NODE_PARAMS = {}
+
+LOCALIZATION_RECORD_TOPIC = """^/tf$\
+|^/diagnostics$\
+|^/localization/pose_estimator/transform_probability$\
+|^/localization/pose_estimator/nearest_voxel_transformation_likelihood$\
+|^/localization/pose_estimator/pose$\
+|^/localization/kinematic_state$\
+|^/localization/util/downsample/pointcloud$\
+|^/localization/pose_estimator/points_aligned$\
+|^/log_evaluator/.*\
+"""
+
+LOCALIZATION_AUTOWARE_DISABLE = {
+    "perception": "false",
+    "planning": "false",
+    "control": "false",
+}
+
+LOCALIZATION_AUTOWARE_ARGS = {
+    "pose_source": "ndt",
+    "twist_source": "gyro_odom",
+}
+
+LOCALIZATION_NODE_PARAMS = {}
+
+OBSTACLE_SEGMENTATION_RECORD_TOPIC = """^/tf$\
+|^/perception/obstacle_segmentation/pointcloud$\
+|^/planning/scenario_planning/trajectory$\
+|^/planning/scenario_planning/status/stop_reasons$\
+|^/log_evaluator/.*\
+"""
+
+OBSTACLE_SEGMENTATION_AUTOWARE_DISABLE = {
+    "localization": "false",
+    "control": "false",
+}
+
+OBSTACLE_SEGMENTATION_AUTOWARE_ARGS = {
+    "scenario_simulation": "true",
+}
+
+OBSTACLE_SEGMENTATION_NODE_PARAMS = {
+    "vehicle_model": LaunchConfiguration("vehicle_model"),
+    "map_path": LaunchConfiguration("map_path"),
+}
+
+PERCEPTION_2D_RECORD_TOPIC = """^/tf$\
+|^/sensing/lidar/concatenated/pointcloud$\
+|^/perception/object_recognition/detection/objects$\
+|^/perception/object_recognition/tracking/objects$\
+|^/perception/object_recognition/objects$\
+|^/sensing/camera/.*\
+|^/log_evaluator/.*\
+"""
+
+PERCEPTION_2D_AUTOWARE_DISABLE = {
+    "localization": "false",
+    "planning": "false",
+    "control": "false",
+}
+
+PERCEPTION_2D_AUTOWARE_ARGS = {
+    "perception_mode": "camera_lidar_fusion",
+}
+
+PERCEPTION_2D_NODE_PARAMS = {}
+
+PERCEPTION_RECORD_TOPIC = """^/tf$\
+|^/sensing/lidar/concatenated/pointcloud$\
+|^/perception/object_recognition/detection/objects$\
+|^/perception/object_recognition/tracking/objects$\
+|^/perception/object_recognition/objects$\
+|^/perception/object_recognition/tracking/multi_object_tracker/debug/.*\
+|^/perception/object_recognition/detection/.*/debug/pipeline_latency_ms$\
+|^/log_evaluator/.*\
+|^/sensing/camera/.*\
+"""
+
+PERCEPTION_AUTOWARE_DISABLE = {
+    "localization": "false",
+    "planning": "false",
+    "control": "false",
+}
+
+PERCEPTION_AUTOWARE_ARGS = {}
+
+PERCEPTION_NODE_PARAMS = {}
+
+PERFORMANCE_DIAG_RECORD_TOPIC = """^/tf$\
+|^/perception/obstacle_segmentation/pointcloud$\
+|^/diagnostics$\
+|^/sensing/lidar/.*/blockage_diag/debug/blockage_mask_image$\
+|^/sensing/lidar/.*/pointcloud_raw_ex$\
+|^/log_evaluator/.*\
+"""
+
+PERFORMANCE_DIAG_AUTOWARE_DISABLE = {
+    "perception": "false",
+    "planning": "false",
+    "control": "false",
+}
+
+
+PERFORMANCE_DIAG_AUTOWARE_ARGS = {}
+
+PERFORMANCE_DIAG_NODE_PARAMS = {}
+
+TRAFFIC_LIGHT_RECORD_TOPIC = """^/tf$\
+|^/sensing/camera/camera[67]/image_raw/compressed$\
+|^/perception/.*/traffic_signals$\
+|^/log_evaluator/.*\
+"""
+
+TRAFFIC_LIGHT_AUTOWARE_DISABLE = {
+    "localization": "false",
+    "planning": "false",
+    "control": "false",
+}
+
+TRAFFIC_LIGHT_AUTOWARE_ARGS = {}
+
+TRAFFIC_LIGHT_NODE_PARAMS = {"map_path": LaunchConfiguration("map_path")}
+
+YABLOC_RECORD_TOPIC = """^/tf$\
+|^/diagnostics$\
+|^/localization/pose_estimator/pose$\
+|^/localization/kinematic_state$\
+|^/localization/util/downsample/pointcloud$\
+|^/localization/pose_estimator/points_aligned$\
+"""
+
+YABLOC_AUTOWARE_DISABLE = {
+    "perception": "false",
+    "planning": "false",
+    "control": "false",
+}
+
+YABLOC_AUTOWARE_ARGS = {
+    "pose_source": "yabloc",
+    "twist_source": "gyro_odom",
+}
+
+YABLOC_NODE_PARAMS = {}
+
 log_evaluator_config = {
-    "localization": {
-        "record": LOCALIZATION_RECORD_TOPIC,
-        "disable": LOCALIZATION_AUTOWARE_DISABLE,
-        "autoware": LOCALIZATION_AUTOWARE_ARGS,
-        "node": LOCALIZATION_NODE_PARAMS,
-    },
-    "eagleye": {
-        "record": EAGLEYE_RECORD_TOPIC,
-        "disable": EAGLEYE_AUTOWARE_DISABLE,
-        "autoware": EAGLEYE_AUTOWARE_ARGS,
-        "node": EAGLEYE_NODE_PARAMS,
+    "annotationless_perception": {
+        "record": ANNOTATIONLESS_PERCEPTION_RECORD_TOPIC,
+        "disable": ANNOTATIONLESS_PERCEPTION_AUTOWARE_DISABLE,
+        "autoware": ANNOTATIONLESS_PERCEPTION_AUTOWARE_ARGS,
+        "node": ANNOTATIONLESS_PERCEPTION_NODE_PARAMS,
     },
     "ar_tag_based_localizer": {
         "record": AR_TAG_BASED_LOCALIZER_RECORD_TOPIC,
@@ -244,17 +237,17 @@ log_evaluator_config = {
         "autoware": AR_TAG_BASED_LOCALIZER_AUTOWARE_ARGS,
         "node": AR_TAG_BASED_LOCALIZER_NODE_PARAMS,
     },
-    "yabloc": {
-        "record": YABLOC_RECORD_TOPIC,
-        "disable": YABLOC_AUTOWARE_DISABLE,
-        "autoware": YABLOC_AUTOWARE_ARGS,
-        "node": YABLOC_NODE_PARAMS,
+    "eagleye": {
+        "record": EAGLEYE_RECORD_TOPIC,
+        "disable": EAGLEYE_AUTOWARE_DISABLE,
+        "autoware": EAGLEYE_AUTOWARE_ARGS,
+        "node": EAGLEYE_NODE_PARAMS,
     },
-    "perception": {
-        "record": PERCEPTION_RECORD_TOPIC,
-        "disable": PERCEPTION_AUTOWARE_DISABLE,
-        "autoware": PERCEPTION_AUTOWARE_ARGS,
-        "node": PERCEPTION_NODE_PARAMS,
+    "localization": {
+        "record": LOCALIZATION_RECORD_TOPIC,
+        "disable": LOCALIZATION_AUTOWARE_DISABLE,
+        "autoware": LOCALIZATION_AUTOWARE_ARGS,
+        "node": LOCALIZATION_NODE_PARAMS,
     },
     "obstacle_segmentation": {
         "record": OBSTACLE_SEGMENTATION_RECORD_TOPIC,
@@ -262,11 +255,17 @@ log_evaluator_config = {
         "autoware": OBSTACLE_SEGMENTATION_AUTOWARE_ARGS,
         "node": OBSTACLE_SEGMENTATION_NODE_PARAMS,
     },
-    "traffic_light": {
-        "record": TRAFFIC_LIGHT_RECORD_TOPIC,
-        "disable": TRAFFIC_LIGHT_AUTOWARE_DISABLE,
-        "autoware": TRAFFIC_LIGHT_AUTOWARE_ARGS,
-        "node": TRAFFIC_LIGHT_NODE_PARAMS,
+    "perception_2d": {
+        "record": PERCEPTION_2D_RECORD_TOPIC,
+        "disable": PERCEPTION_2D_AUTOWARE_DISABLE,
+        "autoware": PERCEPTION_AUTOWARE_ARGS,
+        "node": PERCEPTION_2D_NODE_PARAMS,
+    },
+    "perception": {
+        "record": PERCEPTION_RECORD_TOPIC,
+        "disable": PERCEPTION_AUTOWARE_DISABLE,
+        "autoware": PERCEPTION_AUTOWARE_ARGS,
+        "node": PERCEPTION_NODE_PARAMS,
     },
     "performance_diag": {
         "record": PERFORMANCE_DIAG_RECORD_TOPIC,
@@ -274,16 +273,16 @@ log_evaluator_config = {
         "autoware": PERFORMANCE_DIAG_AUTOWARE_ARGS,
         "node": PERFORMANCE_DIAG_NODE_PARAMS,
     },
-    "perception_2d": {
-        "record": PERCEPTION_2D_RECORD_TOPIC,
-        "disable": PERCEPTION_2D_AUTOWARE_DISABLE,
-        "autoware": PERCEPTION_AUTOWARE_ARGS,
-        "node": PERCEPTION_2D_NODE_PARAMS,
+    "traffic_light": {
+        "record": TRAFFIC_LIGHT_RECORD_TOPIC,
+        "disable": TRAFFIC_LIGHT_AUTOWARE_DISABLE,
+        "autoware": TRAFFIC_LIGHT_AUTOWARE_ARGS,
+        "node": TRAFFIC_LIGHT_NODE_PARAMS,
     },
-    "annotationless_perception": {
-        "record": ANNOTATIONLESS_PERCEPTION_RECORD_TOPIC,
-        "disable": ANNOTATIONLESS_PERCEPTION_AUTOWARE_DISABLE,
-        "autoware": ANNOTATIONLESS_PERCEPTION_AUTOWARE_ARGS,
-        "node": ANNOTATIONLESS_PERCEPTION_NODE_PARAMS,
+    "yabloc": {
+        "record": YABLOC_RECORD_TOPIC,
+        "disable": YABLOC_AUTOWARE_DISABLE,
+        "autoware": YABLOC_AUTOWARE_ARGS,
+        "node": YABLOC_NODE_PARAMS,
     },
 }

--- a/log_evaluator_migration_tool/log_evaluator_migration_tool.py
+++ b/log_evaluator_migration_tool/log_evaluator_migration_tool.py
@@ -34,7 +34,6 @@ def convert_scenario(scenario_path: Path) -> None:
         migration_dict |= {"LocalMapPath": local_map_path}
     if launch_localization != KEY_NOT_EXIST:
         yaml_obj["Evaluation"].pop("LaunchLocalization")
-        migration_dict |= {"LaunchLocalization": launch_localization}
     if initial_pose != KEY_NOT_EXIST:
         yaml_obj["Evaluation"].pop("InitialPose")
         migration_dict |= {"InitialPose": initial_pose}
@@ -94,6 +93,9 @@ def move_dataset_and_map(scenario_path: Path) -> None:
                         )
                     else:
                         print(f"cannot copy {local_map_path}")  # noqa
+                launch_sensing_str: str | None = v.get("LaunchSensing")
+                if launch_sensing_str is not None:
+                    v.pop("LaunchSensing")
         # remove base dir
         t4_dataset_path.rmdir()
 

--- a/sample/perception/scenario.criteria.custom.yaml
+++ b/sample/perception/scenario.criteria.custom.yaml
@@ -9,7 +9,6 @@ Evaluation:
   Datasets:
     - sample_dataset:
         VehicleId: default # Specify VehicleId for each data set.
-        LaunchSensing: false # Specifies whether the sensing module should be activated for each dataset. if false, use concatenated/pointcloud in bag
   Conditions:
     Criterion:
       - PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.

--- a/sample/perception/scenario.fp.ja.yaml
+++ b/sample/perception/scenario.fp.ja.yaml
@@ -9,7 +9,6 @@ Evaluation:
   Datasets:
     - sample_dataset:
         VehicleId: default # データセット毎にVehicleIdを指定する
-        LaunchSensing: false # データセット毎にsensing moduleを起動するかを指定する。falseの場合はbag中にあるconcatenated/pointcloudを使用する
   Conditions:
     Criterion:
       - PassRate: 99.0 # 評価試行回数の内、どの程度(%)評価成功だったら成功とするか

--- a/sample/perception/scenario.fp.yaml
+++ b/sample/perception/scenario.fp.yaml
@@ -9,7 +9,6 @@ Evaluation:
   Datasets:
     - sample_dataset:
         VehicleId: default # Specify VehicleId for each data set.
-        LaunchSensing: false # Specifies whether the sensing module should be activated for each dataset. if false, use concatenated/pointcloud in bag
   Conditions:
     Criterion:
       - PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.

--- a/sample/perception/scenario.ja.yaml
+++ b/sample/perception/scenario.ja.yaml
@@ -9,7 +9,6 @@ Evaluation:
   Datasets:
     - sample_dataset:
         VehicleId: default # データセット毎にVehicleIdを指定する
-        LaunchSensing: false # データセット毎にsensing moduleを起動するかを指定する。falseの場合はbag中にあるconcatenated/pointcloudを使用する
   Conditions:
     Criterion:
       - PassRate: 95.0 # 評価試行回数の内、どの程度(%)評価成功だったら成功とするか

--- a/sample/perception/scenario.yaml
+++ b/sample/perception/scenario.yaml
@@ -9,7 +9,6 @@ Evaluation:
   Datasets:
     - sample_dataset:
         VehicleId: default # Specify VehicleId for each data set.
-        LaunchSensing: false # Specifies whether the sensing module should be activated for each dataset. if false, use concatenated/pointcloud in bag
   Conditions:
     Criterion:
       - PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.

--- a/sample/perception_2d/scenario.ja.yaml
+++ b/sample/perception_2d/scenario.ja.yaml
@@ -9,7 +9,6 @@ Evaluation:
   Datasets:
     - f72e1065-7c38-40fe-a4e2-c5bbe6ff6443:
         VehicleId: ps1/20210620/CAL_000015 # データセット毎にVehicleIdを指定する
-        LaunchSensing: false # データセット毎にsensing moduleを起動するかを指定する
   Conditions:
     PassRate: 99.0 # 評価試行回数の内、どの程度(%)評価成功だったら成功とするか
     CriteriaMethod: num_gt_tp # refer https://github.com/tier4/log_evaluator/blob/develop/log_evaluator/log_evaluator/criteria/perception.py#L136-L152

--- a/sample/perception_2d/scenario.yaml
+++ b/sample/perception_2d/scenario.yaml
@@ -9,7 +9,6 @@ Evaluation:
   Datasets:
     - f72e1065-7c38-40fe-a4e2-c5bbe6ff6443:
         VehicleId: ps1/20210620/CAL_000015 # Specify VehicleId for each data set.
-        LaunchSensing: false # Specifies whether the sensing module should be activated for each dataset. if false, use concatenated/pointcloud in bag
   Conditions:
     PassRate: 99.0 # How much (%) of the evaluation attempts are considered successful.
     CriteriaMethod: num_gt_tp # refer https://github.com/tier4/log_evaluator/blob/develop/log_evaluator/log_evaluator/criteria/perception.py#L136-L152

--- a/sample/performance_diag/scenario.ja.yaml
+++ b/sample/performance_diag/scenario.ja.yaml
@@ -47,5 +47,4 @@ Evaluation:
   Datasets:
     - sample_dataset:
         VehicleId: ps1/20210520/CAL_000012
-        LaunchLocalization: false # falseのときはbagの中に入っている/tfを出力する。trueのときはbagの中のtfはリマップされ無効化される。
-        InitialPose: null # 初期位置を指定する。nullと記述するとGNSSによる初期位置推定を行う。LaunchLocalizationが有効のときだけ機能する
+        InitialPose: null # 初期位置を指定する。nullと記述するとGNSSによる初期位置推定を行う。localization:=true(default)のときだけ機能する

--- a/sample/performance_diag/scenario.yaml
+++ b/sample/performance_diag/scenario.yaml
@@ -47,5 +47,4 @@ Evaluation:
   Datasets:
     - sample_dataset:
         VehicleId: ps1/20210520/CAL_000012
-        LaunchLocalization: false # If false, /tf in the bag is output; if true, /tf in the bag is remapped and disabled.
         InitialPose: null

--- a/sample/traffic_light/scenario.ja.yaml
+++ b/sample/traffic_light/scenario.ja.yaml
@@ -9,7 +9,7 @@ Evaluation:
   Datasets:
     - sample:
         VehicleId: "7" # データセット毎にVehicleIdを指定する
-        LaunchSensing: false # データセット毎にsensing moduleを起動するかを指定する
+
   Conditions:
     Criterion:
       - PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.

--- a/sample/traffic_light/scenario.yaml
+++ b/sample/traffic_light/scenario.yaml
@@ -9,7 +9,6 @@ Evaluation:
   Datasets:
     - sample:
         VehicleId: "7" # Specify VehicleId for each data set.
-        LaunchSensing: false # Specifies whether the sensing module should be activated for each dataset. if false, use concatenated/pointcloud in bag
   Conditions:
     Criterion:
       - PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

- support override autoware launch argument

## How to review this PR

## Others

```shell
# before cannot change sensing component able/disable by launch argument
❯ ros2 launch log_evaluator log_evaluator.launch.py scenario_path:=$HOME/log_evaluator/perception/scenario.yaml
[INFO] [launch]: All log files can be found below /home/hyt/.ros/log/2024-07-23-18-27-40-418459-dpc2405001-1800682
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [launch.user]: dataset_path=PosixPath('/home/hyt/log_evaluator/perception/sample_dataset'), dataset_index=0, output_dir=PosixPath('/home/hyt/log_evaluator/perception/out/2024-0723-182740'), use_case=perception
[INFO] [launch.user]: launch_component={'sensing': 'false', 'localization': 'false', 'perception': 'true', 'planning': 'false', 'control': 'false'}
```

```shell
# after
❯ ros2 launch log_evaluator log_evaluator.launch.py scenario_path:=$HOME/log_evaluator/perception/scenario.yaml sensing:=true
[INFO] [launch]: All log files can be found below /home/hyt/.ros/log/2024-07-23-18-30-16-900564-dpc2405001-1802117
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [launch.user]: dataset_path=PosixPath('/home/hyt/log_evaluator/perception/sample_dataset'), dataset_index=0, output_dir=PosixPath('/home/hyt/log_evaluator/perception/out/2024-0723-183016'), use_case=perception
[INFO] [launch.user]: launch_component={'sensing': 'true', 'localization': 'false', 'perception': 'true', 'planning': 'false', 'control': 'false'}
```